### PR TITLE
Feature/meta attributes

### DIFF
--- a/vitems.nut
+++ b/vitems.nut
@@ -5,10 +5,10 @@ local function erro(str) { printl("[vitems.nut] ERROR: " + str); }
 IncludeScript("libs/vitems/vitems_IdName.nut");
 
 
-// playerTracker -> playerID -> weaponID -> AttributeIDs(From wiki)
-//                           -> playerID -> AttributeIDs(From wiki)
-//                           -> "RemoveAttribsOnDeath"=false
-//                           -> ""
+// playerTracker -> playerID -> weaponID -> AttributeIDs(From wiki)+"metaAttribs":{}
+//                           -> playerID -> AttributeIDs(From wiki)+"metaAttribs":{}
+//                           -> "metaAttribs":
+//                                  +-> RemoveAttribsOnDeath = vitems_default_RemoveAttribsOnDeath
 local playerTracker = {}
 
 

--- a/vitems.nut
+++ b/vitems.nut
@@ -26,12 +26,14 @@ function addPlayerToTracker(playerID)
 {
     playerTracker[playerID] <- {};
     playerTracker[playerID][playerID] <- {}
-    playerTracker[playerID]["RemoveAttribsOnDeath"] <- vitems_default_RemoveAttribsOnDeath;
+    playerTracker[playerID]["metaAttribs"] <- {};
+    playerTracker[playerID]["metaAttribs"]["RemoveAttribsOnDeath"] <- vitems_default_RemoveAttribsOnDeath
 }
 function addPlayerWeaponToTracker(playerID, weaponID)
 {
     if(!(playerID in playerTracker)) addPlayerToTracker(playerID);
     playerTracker[playerID][weaponID] <- {};
+    playerTracker[playerID][weaponID]["metaAttribs"] <- {};
 }
 function addPlayerWeaponAttributeToTracker(playerID, weaponID, attribID, attribVal)
 {
@@ -70,14 +72,88 @@ function getPlayerWeaponAttribute(playerID, weaponID, attribID)
 }
 function resetPlayerAttributes(playerID)
 {
-    if(!(playerID in playerTracker)) return null;
+    if(!(playerID in playerTracker)) return false;
     foreach(k,item in playerTracker[playerID])
     {
-        if(k == "RemoveAttribsOnDeath") continue;
+        if(k == "metaAttribs") continue;
         playerTracker[playerID][k] <- {};
     }
+    return true;
+}
+function removePlayerWeaponAttribute(playerID, weaponID, attribID)
+{
+    if(weaponID == "metaAttribs") return false;
+    if(!(playerID in playerTracker)) return false;
+    if(!(weaponID in playerTracker[playerID]) && weaponID != null) return false;
+    if(!(attribID in playerTracker[playerID][weaponID])) return true;
+    
+    // If weaponID is null, remove all occurences of the attribute in the player's weapons and player
+    if(weaponID == null)
+    {
+        foreach (wID,attribs in playerTracker[playerID]) 
+        {
+            if (wID == "metaAttribs") continue;
+            if (attribID in attribs)
+            {
+                if(attribID == "metaAttribs") continue;
+                playerTracker[playerID][wID].rawdelete(attribID);
+            }
+        }
+    }
+    else
+    {
+        playerTracker[playerID][weaponID].rawdelete(attribID);
+    }
+
+    return true;
 }
 
+function removePlayerAttribute(player, weaponID, attribID)
+{
+    if(weaponID == "metaAttribs") return;
+
+    local attribName <- convertIDToName(attribID);
+    if(attribName == null) { warn("AttribID did not have an existing AttribName, and therefore could not be added/removed"); return; }
+
+    local playerID = player.GetScriptId();
+    if (playerID == null) { warn("A Player Doesn't Have An ID?"); return; }
+
+    local playerAttribs = getPlayerAttributes(playerID);
+	if (playerAttribs == null) { warn("A Player Did Not Have Any Attributes"); return; }
+
+    local weapon = Entities.FindByClassnameWithin(null, "tf_weapon_*", player.GetOrigin(), 50);
+    if(weapon == null) return;
+
+
+    if(playerID == weaponID)
+    {
+        player.RemoveCustomAttribute(attribName, val, -1);
+    }
+    else
+    {
+        while(weapon)
+        {
+            if(weapon.GetOwner() != null)
+            {
+                if(weapon.GetOwner().GetScriptId() == playerID && (weapon.GetScriptId() == weaponID || weaponID == null))
+                {
+                    if(weapon.GetScriptId() in playerAttribs)
+                    {
+                        if(attribID in playerAttribs[weapon.GetScriptId()])
+                        {
+                            if(attribID == "metaAttribs") continue;
+                            weapon.RemoveAttribute(attribName, val, -1);
+                        }
+                    }
+                }
+            }
+
+            weapon = Entities.FindByClassnameWithin(weapon, "tf_weapon_*", player.GetOrigin(), 50);
+        }
+    }
+
+    removePlayerWeaponAttribute(player.GetScriptId(), weaponID, attribID);
+}
 function applyPlayerAttributes(player)
 {
     local playerID = player.GetScriptId();
@@ -100,6 +176,7 @@ function applyPlayerAttributes(player)
                 {
                     foreach (attrib,val in playerAttribs[weapon.GetScriptId()]) 
                     {
+                        if(attrib == "metaAttribs") continue;
                         local attribName = convertIDToName(attrib);
                         if (attribName != null)
                         {
@@ -116,6 +193,7 @@ function applyPlayerAttributes(player)
     // Add Player Attributes
     foreach (attrib,val in playerAttribs[playerID]) 
     {
+        if(attrib == "metaAttribs") continue;
         local attribName = convertIDToName(attrib);
         if (attribName != null)
         {
@@ -146,6 +224,7 @@ function removeAllAttributes(player)
                 {
                     foreach (attrib,val in playerAttribs[weapon.GetScriptId()]) 
                     {
+                        if(attribID == "metaAttribs") continue;
                         local attribName = convertIDToName(attrib);
                         if (attribName != null)
                         {
@@ -162,6 +241,7 @@ function removeAllAttributes(player)
     // Remove Player Attributes
     foreach (attrib,val in playerAttribs[playerID]) 
     {
+        if(attribID == "metaAttribs") continue;
         local attribName = convertIDToName(attrib);
         if (attribName != null)
         {
@@ -182,10 +262,12 @@ function OnGameEvent_player_death(params)
 	if(player == null) { warn("A Player Died, But That Player Doesn't Exist?"); return; }
     if(!(player.GetScriptId() in playerTracker)) { return; }
 
-	if(getPlayerWeaponAttributes(player.GetScriptId(), "RemoveAttribsOnDeath"))
-    {
-        removeAllAttributes(player);
-    }
+
+
+	// if(getPlayerWeaponAttributes(player.GetScriptId(), "RemoveAttribsOnDeath"))
+    // {
+    //     removeAllAttributes(player);
+    // }
 }
 
 function OnGameEvent_player_changeclass(params)


### PR DESCRIPTION
Updated library include method to directly utilize a git clone in a lib directory for scripts.

Adds metaAttribute key under `playerTracker[playerID]` and `playerTracker[playerID][weaponID]` that can hold variables and flags that are relevant to the player or their weapon/body. 

Added several setter and getter functions for metaAttributes. `getPlayerMetaAttribute`, `getPlayerWeaponMetaAttribute`, `setPlayerMetaAttribute`, `setPlayerWeaponMetaAttribute`

Added metaAttribute `RemoveAttribsOnDeath` which when true in the player scope will reset all attributes given to the player and when true in the weapon scope and false in the player scope will only reset the attributes associated with that weapon.

Should this be approved, documentation will need to be edited and expanded. 